### PR TITLE
feat: Add --influxdb.insecureSkipVerify

### DIFF
--- a/pkg/backends/influxdb/influxdb.go
+++ b/pkg/backends/influxdb/influxdb.go
@@ -1,6 +1,7 @@
 package influxdb
 
 import (
+	"crypto/tls"
 	"errors"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -9,6 +10,7 @@ import (
 
 var (
 	serverURL          string
+	insecureSkipVerify bool
 	authToken          string
 	orgName            string
 	metricsBucketName  string
@@ -21,13 +23,19 @@ func NewInfluxDBClient() (influxdb2.Client, error) {
 		return nil, errors.New("--influxdb.serverURL is not set")
 	}
 
-	options := influxdb2.DefaultOptions()
+	options := influxdb2.DefaultOptions().
+		SetTLSConfig(&tls.Config{
+			InsecureSkipVerify: insecureSkipVerify,
+		})
+
 	client := influxdb2.NewClientWithOptions(serverURL, authToken, options)
 	return client, nil
 }
 
 func init() {
 	pflag.StringVar(&serverURL, "influxdb.serverURL", "", "Server URL for InfluxDB.")
+	pflag.BoolVar(&insecureSkipVerify, "influxdb.insecureSkipVerify", false,
+		"Skip TLS verification of the certificate chain and host name for the InfluxDB server.")
 	pflag.StringVar(&authToken, "influxdb.authToken", "", "Auth token to connect to InfluxDB.")
 	pflag.StringVar(&orgName, "influxdb.orgName", "", "InfluxDB organization name.")
 	pflag.StringVar(&metricsBucketName, "influxdb.metricsBucketName", "", "InfluxDB bucket name for metrics.")


### PR DESCRIPTION
Adds a new flag `--influxdb.insecureSkipVerify` which allows bypassing errors in TLS certificate chain or hostname from InfluxDB.