### PR TITLE
Add release GitHub actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ^1.19
 
       - name: Run linters
         uses: golangci/golangci-lint-action@v2
@@ -24,15 +24,15 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17]
+        go-version: [^1.19]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: Version to release (vX.X.X)
+        required: true
+        type: string
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        GOOS: [linux, darwin]
+        GOARCH: [arm, arm64, amd64]
+        exclude:
+          - GOOS: darwin
+            GOARCH: arm
+
+    runs-on: ubuntu-latest
+    env:
+      executable:  apple-health-ingester-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.19
+
+      - name: Get dependencies
+        run: go get -v -t -d ./...
+
+      - name: Test
+        run: go test -v ./...
+
+      - name: Build
+        run: env GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} go build -v -o ${{env.executable}} .
+
+      - name: Create or update release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: ${{env.executable}}
+          tag: ${{input.release_version}}
+          commit: main
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: go test -v ./...
 
       - name: Build
-        run: env GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} go build -v -o ${{env.executable}} .
+        run: env GOOS=${{matrix.GOOS}} GOARCH=${{matrix.GOARCH}} go build -v -o ${{env.executable}} ./cmd/ingester/...
 
       - name: Create or update release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,6 @@ jobs:
         with:
           allowUpdates: true
           artifacts: ${{env.executable}}
-          tag: ${{input.release_version}}
+          tag: ${{inputs.release_version}}
           commit: main
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 .env
 coverage.txt
+.idea
+*.iml

--- a/pkg/backends/localfile/backend.go
+++ b/pkg/backends/localfile/backend.go
@@ -1,7 +1,6 @@
 package localfile
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -114,7 +113,7 @@ func (b *Backend) handleMetric(metric *healthautoexport.Metric, target string) e
 
 func (b *Backend) loadMetrics() (map[string]*MetricFile, error) {
 	output := make(map[string]*MetricFile)
-	files, err := ioutil.ReadDir(metricsPath)
+	files, err := os.ReadDir(metricsPath)
 	if err != nil {
 		// Directory doesn't exist, simply return empty map.
 		if os.IsNotExist(err) {


### PR DESCRIPTION
I'd like to use this! I'd love to have binaries available to easily download from GitHub rather than compiling locally. So I forked your project and threw together a release workflow.

- Updated build workflow versions
- Added (Manual) release workflow that builds for several os/arch targets
- Fixed a linting error about ioutil deprecation

Thanks for this project :)