### PR TITLE
Add TLS support to http server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,12 @@ Usage of ./build/ingester:
       --backend.influxdb                     Enable the InfluxDB storage backend.
       --backend.localfile                    Enable the LocalFile storage backend.
       --http.authToken string                Optional authorization token that will be used to authenticate incoming requests.
+      --http.certFile string                 Certificate file for TLS support.
+      --http.enableTLS                       Enable TLS/HTTPS. Requires setting certificate and key files.
+      --http.keyFile string                  Key file for TLS support.
       --http.listenAddr string               Address to listen on. (default ":8080")
       --influxdb.authToken string            Auth token to connect to InfluxDB.
+      --influxdb.insecureSkipVerify          Skip TLS verification of the certificate chain and host name for the InfluxDB server.
       --influxdb.metricsBucketName string    InfluxDB bucket name for metrics.
       --influxdb.orgName string              InfluxDB organization name.
       --influxdb.serverURL string            Server URL for InfluxDB.

--- a/cmd/ingester/flags.go
+++ b/cmd/ingester/flags.go
@@ -9,6 +9,9 @@ var (
 	authorizationToken string
 	enableInfluxDB     bool
 	enableLocalFile    bool
+	enableTLS          bool
+	certFile           string
+	keyFile            string
 )
 
 func init() {
@@ -17,4 +20,7 @@ func init() {
 		"Optional authorization token that will be used to authenticate incoming requests.")
 	pflag.BoolVar(&enableInfluxDB, "backend.influxdb", false, "Enable the InfluxDB storage backend.")
 	pflag.BoolVar(&enableLocalFile, "backend.localfile", false, "Enable the LocalFile storage backend.")
+	pflag.BoolVar(&enableTLS, "http.enableTLS", false, "Enable TLS/HTTPS. Requires setting certificate and key files.")
+	pflag.StringVar(&certFile, "http.certFile", "", "Certificate file for TLS support.")
+	pflag.StringVar(&keyFile, "http.keyFile", "", "Key file for TLS support.")
 }

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"os"
 	"os/signal"
@@ -33,6 +34,13 @@ func main() {
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  15 * time.Second,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			CurvePreferences: []tls.CurveID{
+				tls.CurveP256,
+				tls.X25519,
+			},
+		},
 	}
 
 	// Initialize and register backends for ingester

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -58,7 +58,13 @@ func main() {
 	// Start http server
 	go func() {
 		log.WithField("listen_addr", listenAddr).Info("starting http server")
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		var err error
+		if enableTLS {
+			err = server.ListenAndServeTLS(certFile, keyFile)
+		} else {
+			err = server.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
 			log.WithError(err).Panicf("cannot start http server")
 		}
 	}()


### PR DESCRIPTION
This is a duplicate of #4 which I'm closing due to extra commits I didn't want in this PR.

I'd like to expose this not just inside my LAN, so I added TLS support, with a minimum TLS version of 1.2. The specific curves was because I read https://blog.cloudflare.com/exposing-go-on-the-internet/.

I've confirmed that this works for myself.

I _will_ have a future PR for sleep metrics changes.

Thanks!