### PR TITLE
Additional sleep analysis support for non-aggregated data

### DIFF
--- a/pkg/backends/influxdb/backend.go
+++ b/pkg/backends/influxdb/backend.go
@@ -131,8 +131,23 @@ func (b *Backend) getMetricPoints(
 			continue
 		}
 
-		point := write.NewPoint(measurement, tags, fields, datum.Date.Time)
-		points = append(points, point)
+		// Add sleep_analysis non-aggregated start date if set
+		if datum.StartDate != nil {
+			startPoint := write.NewPoint(measurement, tags, fields, datum.StartDate.Time)
+			points = append(points, startPoint)
+		}
+
+		// Add sleep_analysis non-aggregated end date if set
+		if datum.EndDate != nil {
+			endPoint := write.NewPoint(measurement, tags, fields, datum.EndDate.Time)
+			points = append(points, endPoint)
+		}
+
+		// Date will be set for all but aggregated sleep_analysis data
+		if datum.Date != nil {
+			point := write.NewPoint(measurement, tags, fields, datum.Date.Time)
+			points = append(points, point)
+		}
 	}
 
 	return points

--- a/pkg/backends/influxdb/backend.go
+++ b/pkg/backends/influxdb/backend.go
@@ -133,12 +133,14 @@ func (b *Backend) getMetricPoints(
 
 		// Add sleep_analysis non-aggregated start date if set
 		if datum.StartDate != nil {
+			fields["state"] = 1
 			startPoint := write.NewPoint(measurement, tags, fields, datum.StartDate.Time)
 			points = append(points, startPoint)
 		}
 
 		// Add sleep_analysis non-aggregated end date if set
 		if datum.EndDate != nil {
+			fields["state"] = 0
 			endPoint := write.NewPoint(measurement, tags, fields, datum.EndDate.Time)
 			points = append(points, endPoint)
 		}

--- a/pkg/healthautoexport/marshal_test.go
+++ b/pkg/healthautoexport/marshal_test.go
@@ -67,6 +67,26 @@ var (
 		},
 	}
 
+	payloadMetricsSleepAnalysisNonAggregated = &healthautoexport.Payload{
+		Data: &healthautoexport.PayloadData{
+			Metrics: []*healthautoexport.Metric{
+				{
+					Name:  "sleep_analysis",
+					Units: "hr",
+					SleepAnalyses: []*healthautoexport.SleepAnalysis{
+						{
+							StartDate: mktime("2021-12-18 02:21:06 +0800"),
+							EndDate:   mktime("2021-12-18 08:57:06 +0800"),
+							Qty:       6.108333333333333,
+							Source:    "Irvin's Apple Watch",
+							Value:     "Core",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	payloadWithWorkouts = &healthautoexport.Payload{
 		Data: &healthautoexport.PayloadData{
 			Workouts: []*healthautoexport.Workout{
@@ -154,6 +174,30 @@ func TestMarshalToString(t *testing.T) {
       }
     ]
   }
+}`,
+		},
+		{
+			name:    "marshal non-aggregated sleep analysis",
+			payload: payloadMetricsSleepAnalysisNonAggregated,
+			want: `{
+	"data": {
+		"metrics": [
+			{
+				"name": "sleep_analysis",
+				"units": "hr",
+				"data": [
+					{
+						"source": "Irvin's Apple Watch",
+						"startDate": "2021-12-18 02:21:06 +0800",
+						"endDate": "2021-12-18 08:57:06 +0800",
+						"value": "Core",
+						"date": null,
+						"qty": 6.108333333333333
+					}
+				]
+			}
+		]
+	}
 }`,
 		},
 	}
@@ -306,6 +350,30 @@ func TestUnmarshalFromString(t *testing.T) {
       }
     ]
   }
+}`,
+		},
+		{
+			name: "unmarshal non-aggregated sleep analysis",
+			want: payloadMetricsSleepAnalysisNonAggregated,
+			input: `{
+	"data": {
+		"metrics": [
+			{
+				"name": "sleep_analysis",
+				"units": "hr",
+				"data": [
+					{
+						"source": "Irvin's Apple Watch",
+						"startDate": "2021-12-18 02:21:06 +0800",
+						"endDate": "2021-12-18 08:57:06 +0800",
+						"value": "Core",
+						"date": null,
+						"qty": 6.108333333333333
+					}
+				]
+			}
+		]
+	}
 }`,
 		},
 	}

--- a/pkg/healthautoexport/types.go
+++ b/pkg/healthautoexport/types.go
@@ -199,7 +199,7 @@ func (w *Datapoint) UnmarshalJSON(bytes []byte) error {
 		return err
 	}
 
-	t := reflect.TypeOf(w)
+	t := reflect.TypeOf(*w)
 	// remove already parsed fields in Datapoint struct, leaving only unknown fields
 	for i := 0; i < t.NumField(); i++ {
 		jsonTag := t.Field(i).Tag.Get("json")

--- a/pkg/healthautoexport/types.go
+++ b/pkg/healthautoexport/types.go
@@ -95,7 +95,7 @@ func (m *Metric) UnmarshalJSON(bytes []byte) error {
 		if err := jsoniter.Unmarshal(mi.Data, &sa); err != nil {
 			return err
 		}
-		if sa[0].Value != "" {
+		if len(sa) > 0 && sa[0].Value != "" {
 			m.SleepAnalyses = sa
 			return nil
 		}


### PR DESCRIPTION
Hey Irvin, here's the new PR I promised:

- Support data sent when "Aggregate Sleep Data" is turned off
  - Two metrics (fields) written: `qty` and `state`
  - Two tags: `source` (e.g. watch/phone/app) and `value` (sleep stage, asleep, awake, inBed) 
  - State field/metric is 2 points per item: set to `1` at `startDate` and `0` at `endDate`
- New `SleepAnalysis` struct to hold structured non-aggregate sleep data
- localfile format unchanged, MarshalJSON still serializes the same
- Aggregated sleep data handling unchanged. It could be modified in the future to be handled in a similar way.
- Tests for (un)marshal changes

Actual sleep metrics from my last night, powered by these changes, from my Grafana (my database is actually [Victoriametrics](https://victoriametrics.com), not Influx): 
<img width="718" alt="image" src="https://user-images.githubusercontent.com/1477390/201483326-7b076c82-e68e-4172-a2b3-0a1ca59af7f4.png">
