### PR TITLE
fix: Support Health Auto Export 6.6.2 sleep phases data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/google/go-cmp v0.5.6
 	github.com/influxdata/influxdb-client-go/v2 v2.6.0
+	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.9.1
@@ -18,7 +19,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.8.2 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
-	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/pkg/backends/influxdb/backend.go
+++ b/pkg/backends/influxdb/backend.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	SleepAnalysisDetailed   = "sleep_analysis_detailed"
-	SleepAnalysisAggregated = "sleep_analysis_aggregated"
+	MeasurementSleepAnalysisDetailed   = "sleep_analysis_detailed"
+	MeasurementSleepAnalysisAggregated = "sleep_analysis_aggregated"
+	MeasurementSleepPhases             = "sleep_phases"
 )
 
 // Backend InfluxDB is used to store ingested metrics into InfluxDB. All metrics
@@ -142,17 +143,34 @@ func (b *Backend) getMetricPoints(metric *healthautoexport.Metric, tags []lp.Tag
 		points = append(points, point)
 	}
 
+	// Add points for detailed sleep analysis.
 	for _, s := range metric.SleepAnalyses {
-		points = append(points, makeSleepPoint(SleepAnalysisDetailed, s.Source, s.Value, 1, nil, s.StartDate, tags))
+		points = append(points, makeSleepPoint(MeasurementSleepAnalysisDetailed, s.Source, s.Value, 1, nil, s.StartDate, tags))
 		// end point has state = 0 (off)
-		points = append(points, makeSleepPoint(SleepAnalysisDetailed, s.Source, s.Value, 0, &s.Qty, s.EndDate, tags))
+		points = append(points, makeSleepPoint(MeasurementSleepAnalysisDetailed, s.Source, s.Value, 0, &s.Qty, s.EndDate, tags))
 	}
 
+	// Add points for aggregated sleep analysis.
 	for _, a := range metric.AggregatedSleepAnalyses {
-		points = append(points, makeSleepPoint(SleepAnalysisAggregated, a.SleepSource, "asleep", 1, nil, a.SleepStart, tags))
-		points = append(points, makeSleepPoint(SleepAnalysisAggregated, a.SleepSource, "asleep", 0, &a.Asleep, a.SleepEnd, tags))
-		points = append(points, makeSleepPoint(SleepAnalysisAggregated, a.InBedSource, "inBed", 1, nil, a.InBedStart, tags))
-		points = append(points, makeSleepPoint(SleepAnalysisAggregated, a.InBedSource, "inBed", 0, &a.InBed, a.InBedEnd, tags))
+		// Support old aggregated sleep analysis format prior to HAE v6.6.2.
+		if a.SleepSource != "" {
+			points = append(points, makeSleepPoint(MeasurementSleepAnalysisAggregated, a.SleepSource, "asleep", 1, nil, a.SleepStart, tags))
+			points = append(points, makeSleepPoint(MeasurementSleepAnalysisAggregated, a.SleepSource, "asleep", 0, &a.Asleep, a.SleepEnd, tags))
+		}
+		if a.InBedSource != "" {
+			points = append(points, makeSleepPoint(MeasurementSleepAnalysisAggregated, a.InBedSource, "inBed", 1, nil, a.InBedStart, tags))
+			points = append(points, makeSleepPoint(MeasurementSleepAnalysisAggregated, a.InBedSource, "inBed", 0, &a.InBed, a.InBedEnd, tags))
+		}
+
+		// Support sleep phase data from HAE v6.6.2 onwards.
+		// All points for sleep phase will use the SleepEnd time.
+		if a.Source != "" {
+			points = append(points, makeSleepPhasePoint(MeasurementSleepPhases, a.Source, "awake", a.Awake, a.SleepEnd, tags))
+			points = append(points, makeSleepPhasePoint(MeasurementSleepPhases, a.Source, "inBed", a.InBed, a.SleepEnd, tags))
+			points = append(points, makeSleepPhasePoint(MeasurementSleepPhases, a.Source, "core", a.Core, a.SleepEnd, tags))
+			points = append(points, makeSleepPhasePoint(MeasurementSleepPhases, a.Source, "deep", a.Deep, a.SleepEnd, tags))
+			points = append(points, makeSleepPhasePoint(MeasurementSleepPhases, a.Source, "rem", a.REM, a.SleepEnd, tags))
+		}
 	}
 
 	return points
@@ -168,6 +186,23 @@ func makeSleepPoint(measurement string, source string, value string,
 		point.AddField("qty", float64(*qty))
 	}
 	point.AddField("state", state)
+	point.SetTime(t.Time)
+	return point
+}
+
+func makeSleepPhasePoint(
+	measurement string,
+	source string,
+	value string,
+	qty healthautoexport.Qty,
+	t *healthautoexport.Time,
+	tags []lp.Tag,
+) *write.Point {
+	point := write.NewPointWithMeasurement(measurement)
+	addTagsToPoint(point, tags)
+	point.AddTag("source", source)
+	point.AddTag("value", value)
+	point.AddField("qty", float64(qty))
 	point.SetTime(t.Time)
 	return point
 }

--- a/pkg/backends/influxdb/backend_test.go
+++ b/pkg/backends/influxdb/backend_test.go
@@ -57,6 +57,18 @@ func TestBackend(t *testing.T) {
 			},
 		},
 		{
+			name:    "write sleep phase metrics",
+			target:  "test",
+			payload: fixtures.PayloadMetricsSleepPhases,
+			wantMetrics: []string{
+				`sleep_phases,target_name=test,source=Irvin's\ iPhone|Irvin’s\ Apple\ Watch,value=awake qty=0.11666666666666667 1675125552000000000`,
+				`sleep_phases,target_name=test,source=Irvin's\ iPhone|Irvin’s\ Apple\ Watch,value=inBed qty=8.145010935001903 1675125552000000000`,
+				`sleep_phases,target_name=test,source=Irvin's\ iPhone|Irvin’s\ Apple\ Watch,value=core qty=3.2999999999999994 1675125552000000000`,
+				`sleep_phases,target_name=test,source=Irvin's\ iPhone|Irvin’s\ Apple\ Watch,value=deep qty=0.8583333333333334 1675125552000000000`,
+				`sleep_phases,target_name=test,source=Irvin's\ iPhone|Irvin’s\ Apple\ Watch,value=rem qty=1.2583333333333333 1675125552000000000`,
+			},
+		},
+		{
 			name:    "write non aggregated sleep analysis metrics",
 			target:  "test",
 			payload: fixtures.PayloadMetricsSleepAnalysisNonAggregated,
@@ -143,7 +155,7 @@ func (b *BackendTest) AssertWriteWorkouts(t *testing.T, payload *healthautoexpor
 
 func (b *BackendTest) assertPoints(t *testing.T, expectedLines []string, actual []*write.Point) {
 	if len(expectedLines) != len(actual) {
-		assert.Equal(t, len(expectedLines), len(actual), fmt.Sprintf("points are not equal length: %v vs %v", expectedLines, actual))
+		assert.Equal(t, len(expectedLines), len(actual), fmt.Sprintf("points are not equal length: %v vs %v", expectedLines, formatPoints(actual)))
 		return
 	}
 	for i := 0; i < len(expectedLines); i++ {
@@ -152,7 +164,19 @@ func (b *BackendTest) assertPoints(t *testing.T, expectedLines []string, actual 
 }
 
 func (b *BackendTest) assertPoint(t *testing.T, expectedLine string, actual *write.Point, msgAndArgs ...interface{}) {
-	actualLine := write.PointToLineProtocol(actual, time.Nanosecond)
-	actualLine = strings.TrimSuffix(actualLine, "\n")
+	actualLine := formatPoint(actual)
 	assert.Equalf(t, expectedLine, actualLine, "%v: diff = %v", fmt.Sprint(msgAndArgs...), cmp.Diff(expectedLine, actualLine))
+}
+
+func formatPoint(p *write.Point) string {
+	line := write.PointToLineProtocol(p, time.Nanosecond)
+	return strings.TrimSuffix(line, "\n")
+}
+
+func formatPoints(points []*write.Point) []string {
+	strs := make([]string, 0, len(points))
+	for _, point := range points {
+		strs = append(strs, formatPoint(point))
+	}
+	return strs
 }

--- a/pkg/healthautoexport/fixtures/fixtures.go
+++ b/pkg/healthautoexport/fixtures/fixtures.go
@@ -133,6 +133,30 @@ var (
 			},
 		},
 	}
+
+	PayloadMetricsSleepPhases = &healthautoexport.Payload{
+		Data: &healthautoexport.PayloadData{
+			Metrics: []*healthautoexport.Metric{
+				{
+					Name:  "sleep_analysis",
+					Units: "hr",
+					AggregatedSleepAnalyses: []*healthautoexport.AggregatedSleepAnalysis{
+						{
+							Asleep:     0,
+							SleepStart: mktime("2023-01-31 00:23:47 +0800"),
+							SleepEnd:   mktime("2023-01-31 08:39:12 +0800"),
+							Source:     "Irvin's iPhone|Irvin’s Apple Watch",
+							InBed:      8.1450109350019027,
+							Core:       3.2999999999999994,
+							Awake:      0.11666666666666667,
+							Deep:       0.85833333333333339,
+							REM:        1.2583333333333333,
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 func mktime(ts string) *healthautoexport.Time {

--- a/pkg/healthautoexport/marshal_test.go
+++ b/pkg/healthautoexport/marshal_test.go
@@ -262,6 +262,36 @@ func TestUnmarshalFromString(t *testing.T) {
 	}
 }`,
 		},
+		{
+			// Support new aggregated sleep_analysis format from HAE v6.6.2 onwards.
+			// https://github.com/irvinlim/apple-health-ingester/issues/20
+			name: "unmarshal aggregated sleep analysis",
+			want: fixtures.PayloadMetricsSleepPhases,
+			input: `{
+  "data": {
+    "metrics": [
+      {
+        "data": [
+          {
+            "inBed": 8.1450109350019027,
+            "deep": 0.85833333333333339,
+            "rem": 1.2583333333333333,
+            "sleepEnd": "2023-01-31 08:39:12 +0800",
+            "source": "Irvin's iPhone|Irvin’s Apple Watch",
+            "core": 3.2999999999999994,
+            "date": "2023-01-31 02:44:02 +0800",
+            "sleepStart": "2023-01-31 00:23:47 +0800",
+            "asleep": 0,
+            "awake": 0.11666666666666667
+          }
+        ],
+        "units": "hr",
+        "name": "sleep_analysis"
+      }
+    ]
+  }
+}`,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/healthautoexport/types.go
+++ b/pkg/healthautoexport/types.go
@@ -61,14 +61,56 @@ type SleepAnalysis struct {
 // It is only valid for aggregate sleep analysis data ("Aggregate Sleep Data" is enabled)
 type AggregatedSleepAnalysis struct {
 	// we don't parse "date" which doesn't seem to have useful interesting information
-	Asleep      Qty    `json:"asleep"`
-	SleepSource string `json:"sleepSource"`
-	SleepStart  *Time  `json:"sleepStart"`
-	SleepEnd    *Time  `json:"sleepEnd"`
-	InBed       Qty    `json:"inBed"`
-	InBedSource string `json:"inBedSource"`
-	InBedStart  *Time  `json:"inBedStart"`
-	InBedEnd    *Time  `json:"inBedEnd"`
+
+	// Start time of sleep.
+	SleepStart *Time `json:"sleepStart"`
+
+	// End time of sleep.
+	SleepEnd *Time `json:"sleepEnd"`
+
+	// Asleep duration in hours.
+	// This will always be 0 and broken down into Core, Deep and REM from HAE v6.6.2 onwards.
+	Asleep Qty `json:"asleep"`
+
+	// InBed duration in hours.
+	InBed Qty `json:"inBed"`
+
+	// Awake duration in hours.
+	// Only available from HAE v6.6.2 onwards.
+	Awake Qty `json:"awake,omitempty"`
+
+	// Core sleep duration in hours.
+	// Only available from HAE v6.6.2 onwards.
+	Core Qty `json:"core,omitempty"`
+
+	// Deep sleep duration in hours.
+	// Only available from HAE v6.6.2 onwards.
+	Deep Qty `json:"deep,omitempty"`
+
+	// REM sleep duration in hours.
+	// Only available from HAE v6.6.2 onwards.
+	REM Qty `json:"rem,omitempty"`
+
+	// Start time of inBed phase.
+	// Only available prior to HAE v6.6.2.
+	InBedStart *Time `json:"inBedStart,omitempty"`
+
+	// End time of inBed phase.
+	// Only available prior to HAE v6.6.2.
+	InBedEnd *Time `json:"inBedEnd,omitempty"`
+
+	// Data source of sleep data.
+	// Multiple source names will be joined together with a pipe (|).
+	// Only available from HAE v6.6.2 onwards.
+	Source string `json:"source,omitempty"`
+
+	// Data source of sleep phase.
+	// Only available prior to HAE v6.6.2.
+	SleepSource string `json:"sleepSource,omitempty"`
+
+	// Data source of inBed phase.
+	// Only available prior to HAE v6.6.2.
+	InBedSource string `json:"inBedSource,omitempty"`
 }
 
 func (m *Metric) GetUnits() Units {
@@ -111,25 +153,10 @@ func (m *Metric) UnmarshalJSON(bytes []byte) error {
 	}
 	switch m.Name {
 	case SleepAnalysisName:
-		var sa []*SleepAnalysis
-		if err := jsoniter.Unmarshal(intermediate.Data, &sa); err != nil {
-			return err
+		// Try to unmarshal as sleep_analysis on best-effort basis.
+		if m.unmarshalSleepAnalysis(intermediate.Data) {
+			break
 		}
-		// only process as SleepAnalysis if first item parses to non-empty SleepAnalysis
-		if len(sa) > 0 && *sa[0] != (SleepAnalysis{}) {
-			m.SleepAnalyses = sa
-			return nil
-		}
-		var agg []*AggregatedSleepAnalysis
-		if err := jsoniter.Unmarshal(intermediate.Data, &agg); err != nil {
-			return err
-		}
-		// only process as AggregatedSleepAnalysis if first item parses to non-empty AggregatedSleepAnalysis
-		if len(agg) > 0 && *agg[0] != (AggregatedSleepAnalysis{}) {
-			m.AggregatedSleepAnalyses = agg
-			return nil
-		}
-		// if neither type of sleep analysis parsed something, parse as a Datapoint.
 		fallthrough
 	default:
 		if intermediate.Data == nil {
@@ -140,8 +167,34 @@ func (m *Metric) UnmarshalJSON(bytes []byte) error {
 			return err
 		}
 		m.Datapoints = d
-		return nil
 	}
+
+	return nil
+}
+
+func (m *Metric) unmarshalSleepAnalysis(data []byte) bool {
+	// Try to unmarshal as SleepAnalysis first.
+	// However, it seems that later versions of Apple Health no longer expose this information.
+	var sa []*SleepAnalysis
+	if err := jsoniter.Unmarshal(data, &sa); err == nil {
+		// Non-aggregated sleep_analysis should always have StartDate and EndDate set.
+		if len(sa) > 0 && !sa[0].StartDate.IsZero() && !sa[0].EndDate.IsZero() {
+			m.SleepAnalyses = sa
+			return true
+		}
+	}
+
+	// Try to unmarshal as AggregatedSleepAnalysis.
+	var agg []*AggregatedSleepAnalysis
+	if err := jsoniter.Unmarshal(data, &agg); err == nil {
+		// Aggregated sleep_analysis should always have SleepStart and SleepEnd set.
+		if len(agg) > 0 && !agg[0].SleepStart.IsZero() && !agg[0].SleepEnd.IsZero() {
+			m.AggregatedSleepAnalyses = agg
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m *Metric) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Fixes #20.

## Summary

This PR aims to cover two main things:

1. Previous parsing and differentiating aggregated/non-aggregated sleep analysis data were not robust, and resulted in nil pointers because of bad assumptions.
2. Health Auto Export v6.6.2 (released yesterday) introduced non-backwards compatible changes to aggregated sleep analysis data, but introduced new sleep phases data. We introduce a new measurement `sleep_phases` that would cover the new data instead.

## Changes in Health Auto Export 6.6.2

### Non-Aggregated Sleep Analysis

Sleep phases are now exported.

<details>
<summary>View example payload...</summary>

```json
{
  "data": {
    "metrics": [
      {
        "data": [
          {
            "qty": 5.9363998238907918,
            "source": "Irvin's iPhone",
            "startDate": "2023-01-31 02:44:02 +0800",
            "value": "InBed",
            "endDate": "2023-01-31 08:40:13 +0800"
          },
          {
            "startDate": "2023-01-31 03:07:12 +0800",
            "qty": 0.23333333333333334,
            "endDate": "2023-01-31 03:21:12 +0800",
            "value": "Core",
            "source": "Irvin’s Apple Watch"
          },
          {
            "endDate": "2023-01-31 03:55:42 +0800",
            "qty": 0.80833333333333335,
            "value": "InBed",
            "startDate": "2023-01-31 03:07:12 +0800",
            "source": "Irvin’s Apple Watch"
          },
          {
            "qty": 0.066666666666666666,
            "source": "Irvin’s Apple Watch",
            "startDate": "2023-01-31 03:21:12 +0800",
            "value": "Deep",
            "endDate": "2023-01-31 03:25:12 +0800"
          },
          {
            "startDate": "2023-01-31 03:25:12 +0800",
            "source": "Irvin’s Apple Watch",
            "value": "Core",
            "qty": 0.14166666666666666,
            "endDate": "2023-01-31 03:33:42 +0800"
          },
          ...
        ],
        "name": "sleep_analysis",
        "units": "hr"
      }
    ]
  }
}
```

</details>

### Aggregated Sleep Analysis

The data format for aggregated sleep analysis data is now significantly different.

1. `asleep` is now always 0, and is broken down into `core`, `deep` and `rem`.
2. `inBedStart`/`inBedEnd` are no longer present.
3. `source` is now added.
4. `awake` is now added.

<details>
<summary>View example payload...</summary>

```json
{
  "data": {
    "metrics": [
      {
        "data": [
          {
            "deep": 1.1083333333333334,
            "date": "2023-01-26 02:24:34 +0800",
            "asleep": 0,
            "inBed": 7.2526607961124849,
            "source": "Irvin’s Apple Watch|Irvin's iPhone",
            "sleepStart": "2023-01-26 00:29:29 +0800",
            "rem": 0.80833333333333335,
            "sleepEnd": "2023-01-26 08:49:48 +0800",
            "core": 3.9416666666666669,
            "awake": 0.20833333333333331
          }
        ],
        "name": "sleep_analysis",
        "units": "hr"
      }
    ]
  }
}
```

</details>

## Changes

1. Revamp `unmarshalSleepAnalysis` to check for the existence of must-have fields instead of empty struct check.
   - Aggregated sleep analysis datapoints MUST have `sleepStart`/`sleepEnd`
   - Non-aggregated datapoints MUST have `startDate`/`endDate`
   - I hope that this doesn't change again in the future, but I think that these assumptions seem reasonable.
2. Support both pre-6.6.2 and post-6.6.2 fields for aggregated sleep analysis data.
   - Changes in fields are outlined above, as well as in the GoDoc for `AggregatedSleepAnalysis`.
3. When writing to InfluxDB, we will choose to either support pre-6.6.2 or post-6.6.2 data.
   - Notably, `source` was added in 6.6.2 and removed `sleepSource`/`inBedSource`, so we use these to make a distinction.
4. Add new measurement `sleep_phases`.
   - Supports 5 metrics in total: `awake`, `inBed`, `core`, `deep`, `rem`

I was thinking that because in 6.6.2 onwards, we now no longer have `inBed`/`sleep` start/end times, and only have a single sleep start/end for all 5 kinds of metrics. As such, I chose to introduce a new metric `sleep_phases` (in line with the naming chosen by Health Auto Export), since we are unable to maintain backwards compatibility with `sleep_analysis_aggregated` with the `state` value.