### PR TITLE
Add multi-arch support to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # stage: 0
-FROM golang:1.17 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.17 AS builder
+ARG TARGETOS TARGETARCH
 
 WORKDIR /go/src/workspace
 
@@ -9,7 +10,7 @@ RUN go mod download
 
 # Add application code and install binary
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build \
     -a -v \
     -tags netgo \

--- a/hack/push-docker-multiarch.sh
+++ b/hack/push-docker-multiarch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+IMAGE_NAME="irvinlim/apple-health-ingester"
+
+docker build -t "${IMAGE_NAME}:latest" .
+
+# Use git commit hash for untagged git builds
+COMMIT_TAG=$(git rev-parse HEAD | cut -c1-12)
+docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${COMMIT_TAG}"
+docker push "${IMAGE_NAME}:latest"
+docker push "${IMAGE_NAME}:${COMMIT_TAG}"
+
+# Also push with additional tag if git tag is set
+GIT_TAG=$(git tag --points-at HEAD)
+if [[ -n "${GIT_TAG}" ]]; then
+  docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${GIT_TAG}"
+  docker push "${IMAGE_NAME}:${GIT_TAG}"
+fi

--- a/hack/push-docker-multiarch.sh
+++ b/hack/push-docker-multiarch.sh
@@ -15,4 +15,6 @@ if [[ -n "${GIT_TAG}" ]]; then
   IMAGE_TAG_ARGS+=(--tag "${IMAGE_NAME}:${GIT_TAG}")
 fi
 
-docker build "${IMAGE_TAG_ARGS[@]}" --push .
+# create builder with multi-arch build support
+docker buildx create --use
+docker buildx build --platform 'linux/amd64,linux/arm64' "${IMAGE_TAG_ARGS[@]}" --push .

--- a/hack/push-docker-multiarch.sh
+++ b/hack/push-docker-multiarch.sh
@@ -3,18 +3,16 @@
 set -euxo pipefail
 
 IMAGE_NAME="irvinlim/apple-health-ingester"
-
-docker build -t "${IMAGE_NAME}:latest" .
+IMAGE_TAG_ARGS=(--tag "${IMAGE_NAME}:latest")
 
 # Use git commit hash for untagged git builds
 COMMIT_TAG=$(git rev-parse HEAD | cut -c1-12)
-docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${COMMIT_TAG}"
-docker push "${IMAGE_NAME}:latest"
-docker push "${IMAGE_NAME}:${COMMIT_TAG}"
+IMAGE_TAG_ARGS+=(--tag "${IMAGE_NAME}:${COMMIT_TAG}")
 
-# Also push with additional tag if git tag is set
+# Include additional tag if git tag is set
 GIT_TAG=$(git tag --points-at HEAD)
 if [[ -n "${GIT_TAG}" ]]; then
-  docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${GIT_TAG}"
-  docker push "${IMAGE_NAME}:${GIT_TAG}"
+  IMAGE_TAG_ARGS+=(--tag "${IMAGE_NAME}:${GIT_TAG}")
 fi
+
+docker build "${IMAGE_TAG_ARGS[@]}" --push .


### PR DESCRIPTION
I recently migrated my metrics server to a Raspberry Pi and discovered that my I could no longer run this image. I've added arm64 support to my own fork and figured I might as well submit a PR.

I've added a [copy of the build script](https://github.com/irvinlim/apple-health-ingester/commit/8824983c8cbd90508c8e93cfb599d9d0768f2b07) that handles multi-arch docker builds while trying to make as few changes as possible. It handles building for both linux/amd64 and linux/arm64. A couple notes on the build script:
- The target architectures are hardcoded right now.
- The easiest way to push docker buildx images is to use a single build call which include all of the desired tags and pushes the built images. That's what the odd bash array of image tag arguments is for ([relevant commit](https://github.com/kylekingcdn/apple-health-ingester/commit/399c10035793f86ff6ffb5c058d36b0a47825bc0)).

The original (unmodified) build script continues to work fine with the Dockerfile changes i've made.

I've pushed an image made with these changes to my own [docker hub repo](https://hub.docker.com/r/kylekingcdn/apple-health-ingester) as an example result.