### PR TITLE
feat: Improve log output

### DIFF
--- a/pkg/backends/influxdb/backend_test.go
+++ b/pkg/backends/influxdb/backend_test.go
@@ -25,13 +25,22 @@ func TestBackend(t *testing.T) {
 		wantWorkouts []string
 	}{
 		{
+			name:    "write nil payload",
+			payload: nil,
+		},
+		{
+			name:    "write nil payload data",
+			payload: &healthautoexport.Payload{Data: nil},
+		},
+		{
 			name:   "write active energy metrics",
 			target: "test",
 			payload: &healthautoexport.Payload{
 				Data: &healthautoexport.PayloadData{
 					Metrics: []*healthautoexport.Metric{fixtures.MetricActiveEnergy},
 				},
-			}, wantMetrics: []string{
+			},
+			wantMetrics: []string{
 				"active_energy_kJ,target_name=test qty=0.7685677437484512 1640275440000000000",
 				"active_energy_kJ,target_name=test qty=0.377848256251549 1640275500000000000",
 			},
@@ -43,7 +52,8 @@ func TestBackend(t *testing.T) {
 				Data: &healthautoexport.PayloadData{
 					Metrics: []*healthautoexport.Metric{fixtures.MetricBasalBodyTemperatureNoData},
 				},
-			}, wantMetrics: []string{},
+			},
+			wantMetrics: []string{},
 		},
 		{
 			name:    "write aggregated sleep analysis metrics",

--- a/pkg/util/time/time.go
+++ b/pkg/util/time/time.go
@@ -1,0 +1,33 @@
+package time
+
+import (
+	"fmt"
+	"time"
+)
+
+// MinTimeNonZero returns the smallest time.Time from the input timestamps, excluding zero times.
+func MinTimeNonZero(ts ...time.Time) time.Time {
+	var minTime time.Time
+	for _, t := range ts {
+		if !t.IsZero() && (minTime.IsZero() || t.Before(minTime)) {
+			minTime = t
+		}
+	}
+	return minTime
+}
+
+// MaxTime returns the largest time.Time from the input timestamps.
+func MaxTime(ts ...time.Time) time.Time {
+	var maxTime time.Time
+	for _, t := range ts {
+		if maxTime.IsZero() || t.After(maxTime) {
+			maxTime = t
+		}
+	}
+	return maxTime
+}
+
+// FormatTimeRange outputs a time range as a formatted string.
+func FormatTimeRange(start, end time.Time, layout string) string {
+	return fmt.Sprintf("%v - %v", start.Format(layout), end.Format(layout))
+}

--- a/pkg/util/time/time_test.go
+++ b/pkg/util/time/time_test.go
@@ -1,0 +1,84 @@
+package time
+
+import (
+	"testing"
+	"time"
+)
+
+var (
+	ts1        = mktime("2024-10-24T17:58:09Z")
+	ts2        = mktime("2024-10-24T17:58:10Z")
+	tsNegative = mktime("1969-10-24T17:58:10Z")
+)
+
+func TestMinTimeNonZero(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   []time.Time
+		want time.Time
+	}{
+		{name: "no inputs"},
+		{name: "zero timestamp", ts: []time.Time{{}}},
+		{name: "non-zero timestamp", ts: []time.Time{ts1}, want: ts1},
+		{name: "multiple timestamps", ts: []time.Time{ts1, ts2}, want: ts1},
+		{name: "only negative timestamp", ts: []time.Time{tsNegative}, want: tsNegative},
+		{name: "negative timestamp in list", ts: []time.Time{ts1, tsNegative}, want: tsNegative},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MinTimeNonZero(tt.ts...); !got.Equal(tt.want) {
+				t.Errorf("MinTimeNonZero not equal, want %v got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestMaxTime(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   []time.Time
+		want time.Time
+	}{
+		{name: "no inputs"},
+		{name: "zero timestamp", ts: []time.Time{{}}},
+		{name: "non-zero timestamp", ts: []time.Time{ts1}, want: ts1},
+		{name: "multiple timestamps", ts: []time.Time{ts1, ts2}, want: ts2},
+		{name: "only negative timestamp", ts: []time.Time{tsNegative}, want: tsNegative},
+		{name: "negative timestamp in list", ts: []time.Time{ts1, tsNegative}, want: ts1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MaxTime(tt.ts...); !got.Equal(tt.want) {
+				t.Errorf("MinTimeNonZero not equal, want %v got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestFormatTimeRange(t *testing.T) {
+	tests := []struct {
+		name   string
+		start  time.Time
+		end    time.Time
+		layout string
+		want   string
+	}{
+		{name: "basic test", start: ts1, end: ts2, layout: time.RFC3339, want: "2024-10-24T17:58:09Z - 2024-10-24T17:58:10Z"},
+		{name: "custom time format", start: ts1, end: ts2, layout: time.DateTime, want: "2024-10-24 17:58:09 - 2024-10-24 17:58:10"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatTimeRange(tt.start, tt.end, tt.layout); got != tt.want {
+				t.Errorf("FormatTimeRange() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func mktime(ts string) time.Time {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}


### PR DESCRIPTION
Adds more useful log output and clean up unnecessary log lines.

1. Outputs the `time_range` for each ingestion. When "Batch Requests" is used, this helps to easily identify the current batch that was last sent, in case you need to retry from the last timestamp that failed.
2. Removes `"start writing all {metrics,workouts}"` logs by skipping writes when either of them are not in the payload.

Also handled possible nil pointer (though it shouldn't normally happen).