### PR TITLE
chore: Bump to go1.23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,21 @@ on:
     branches: [ main ]
 
 jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      go_version: ${{ steps.go_version.outputs.GO_VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Determine Go version from go.mod
+        id: go_version
+        run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_OUTPUT
+
   lint:
     runs-on: ubuntu-latest
+    needs: metadata
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -16,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.19
+          go-version: ${{ needs.metadata.outputs.go_version }}
 
       - name: Run linters
         uses: golangci/golangci-lint-action@v2
@@ -24,9 +37,9 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [^1.19]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
+    needs: metadata
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -34,7 +47,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ needs.metadata.outputs.go_version }}
 
       - name: Run tests
         run: go test -v -coverprofile=coverage.txt -covermode=count ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/irvinlim/apple-health-ingester
 
-go 1.17
+go 1.23
 
 require (
 	github.com/google/go-cmp v0.5.6


### PR DESCRIPTION
Also updates `build.yml` to ensure that the Go versions used are the same, by reading from `go.mod` to determine the Go build environment.