### PR TITLE
feat: added import of State of Mind and Symptoms

### DIFF
--- a/pkg/backends/influxdb/backend.go
+++ b/pkg/backends/influxdb/backend.go
@@ -20,6 +20,8 @@ const (
 	MeasurementSleepAnalysisDetailed   = "sleep_analysis_detailed"
 	MeasurementSleepAnalysisAggregated = "sleep_analysis_aggregated"
 	MeasurementSleepPhases             = "sleep_phases"
+	MeasurementStateOfMind             = "state_of_mind"
+	MeasurementSymptom                 = "symptom"
 )
 
 // Backend InfluxDB is used to store ingested metrics into InfluxDB. All metrics
@@ -79,6 +81,18 @@ func (b *Backend) Write(payload *healthautoexport.Payload, targetName string) er
 	if len(payload.Data.Workouts) > 0 {
 		if err := b.writeWorkouts(payload.Data.Workouts, targetName); err != nil {
 			return errors.Wrapf(err, "write workouts error")
+		}
+	}
+
+	if len(payload.Data.StateOfMind) > 0 {
+		if err := b.writeStateOfMind(payload.Data.StateOfMind, targetName); err != nil {
+			return errors.Wrapf(err, "write state of mind error")
+		}
+	}
+
+	if len(payload.Data.Symptoms) > 0 {
+		if err := b.writeSymptoms(payload.Data.Symptoms, targetName); err != nil {
+			return errors.Wrapf(err, "write symptoms error")
 		}
 	}
 
@@ -234,6 +248,138 @@ func makeSleepPhasePoint(
 	point.AddTag("value", value)
 	point.AddField("qty", float64(qty))
 	point.SetTime(t.Time)
+	return point
+}
+
+func (b *Backend) writeStateOfMind(states []*healthautoexport.StateOfMind, targetName string) error {
+	logger := log.WithFields(log.Fields{
+		"backend":    b.Name(),
+		"target":     targetName,
+		"num_states": len(states),
+	})
+
+	startTime := time.Now()
+	logger.Info("start writing all state of mind entries")
+
+	tags := []lp.Tag{
+		{Key: "target_name", Value: targetName},
+	}
+	tags = append(tags, b.staticTags...)
+
+	points := make([]*write.Point, 0, len(states))
+	for _, state := range states {
+		point := b.createStateOfMindPoint(state, tags)
+		if point != nil {
+			points = append(points, point)
+		}
+	}
+
+	if len(points) > 0 {
+		logger := logger.WithFields(log.Fields{
+			"count": len(points),
+		})
+		startTime := time.Now()
+		logger.Debug("writing state of mind points")
+		if err := b.client.WriteMetrics(b.ctx, points...); err != nil {
+			return errors.Wrapf(err, "write error for state of mind")
+		}
+		logger.WithField("elapsed", time.Since(startTime)).Debug("write state of mind points success")
+	}
+
+	logger.WithFields(log.Fields{
+		"points":  len(points),
+		"elapsed": time.Since(startTime),
+	}).Info("write all state of mind entries success")
+
+	return nil
+}
+
+func (b *Backend) createStateOfMindPoint(state *healthautoexport.StateOfMind, tags []lp.Tag) *write.Point {
+	if state.Start.IsZero() {
+		return nil
+	}
+	point := write.NewPointWithMeasurement(MeasurementStateOfMind)
+	addTagsToPoint(point, tags)
+
+	point.AddTag("kind", state.Kind)
+	if len(state.Labels) > 0 {
+		point.AddTag("labels", strings.Join(state.Labels, ","))
+	}
+	if len(state.Associations) > 0 {
+		point.AddTag("associations", strings.Join(state.Associations, ","))
+	}
+
+	point.AddField("valence", state.Valence)
+	point.AddTag("valence_classification", state.ValenceClassification)
+	point.AddField("duration", state.End.Sub(state.Start.Time).Seconds())
+
+	for k, v := range state.Metadata {
+		point.AddField(fmt.Sprintf("metadata_%s", k), v)
+	}
+
+	point.SetTime(state.Start.Time)
+	return point
+}
+
+func (b *Backend) writeSymptoms(symptoms []*healthautoexport.Symptom, targetName string) error {
+	logger := log.WithFields(log.Fields{
+		"backend":      b.Name(),
+		"target":       targetName,
+		"num_symptoms": len(symptoms),
+	})
+
+	startTime := time.Now()
+	logger.Info("start writing all symptoms")
+
+	tags := []lp.Tag{
+		{Key: "target_name", Value: targetName},
+	}
+	tags = append(tags, b.staticTags...)
+
+	points := make([]*write.Point, 0, len(symptoms))
+	for _, symptom := range symptoms {
+		point := b.createSymptomPoint(symptom, tags)
+		if point != nil {
+			points = append(points, point)
+		}
+	}
+
+	if len(points) > 0 {
+		logger := logger.WithFields(log.Fields{
+			"count": len(points),
+		})
+		startTime := time.Now()
+		logger.Debug("writing symptom points")
+		if err := b.client.WriteMetrics(b.ctx, points...); err != nil {
+			return errors.Wrapf(err, "write error for symptoms")
+		}
+		logger.WithField("elapsed", time.Since(startTime)).Debug("write symptom points success")
+	}
+
+	logger.WithFields(log.Fields{
+		"points":  len(points),
+		"elapsed": time.Since(startTime),
+	}).Info("write all symptoms success")
+
+	return nil
+}
+
+func (b *Backend) createSymptomPoint(symptom *healthautoexport.Symptom, tags []lp.Tag) *write.Point {
+	if symptom.Start.IsZero() {
+		return nil
+	}
+	point := write.NewPointWithMeasurement(MeasurementSymptom)
+	addTagsToPoint(point, tags)
+
+	point.AddTag("name", symptom.Name)
+	point.AddTag("severity", symptom.Severity)
+	point.AddTag("source", symptom.Source)
+
+	point.AddField("user_entered", symptom.UserEntered)
+	point.AddField("duration", symptom.End.Sub(symptom.Start.Time).Seconds())
+	point.AddField("cycle_start", symptom.CycleStart)
+
+	point.SetTime(symptom.Start.Time)
 	return point
 }
 

--- a/pkg/healthautoexport/types.go
+++ b/pkg/healthautoexport/types.go
@@ -31,6 +31,7 @@ var (
 
 	// TimeFormats contains all known time formats to parse timestamp by.
 	TimeFormats = []string{
+		time.RFC3339,
 		// Using 24-Hour Time
 		"2006-01-02 15:04:05 -0700",
 		// In case General > Date & Time > 24-Hour Time is set to false
@@ -47,8 +48,10 @@ type Payload struct {
 }
 
 type PayloadData struct {
-	Metrics  []*Metric  `json:"metrics,omitempty"`
-	Workouts []*Workout `json:"workouts,omitempty"`
+	Metrics     []*Metric      `json:"metrics,omitempty"`
+	Workouts    []*Workout     `json:"workouts,omitempty"`
+	StateOfMind []*StateOfMind `json:"stateOfMind,omitempty"`
+	Symptoms    []*Symptom     `json:"symptoms,omitempty"`
 }
 
 // Metric defines a single measurement with units, as well as time-series data points.
@@ -137,6 +140,30 @@ type AggregatedSleepAnalysis struct {
 
 func (m *Metric) GetUnits() Units {
 	return m.Units
+}
+
+// StateOfMind defines a single state of mind entry.
+type StateOfMind struct {
+	ID                    string            `json:"id"`
+	Start                 *Time             `json:"start"`
+	End                   *Time             `json:"end"`
+	Kind                  string            `json:"kind"`
+	Labels                []string          `json:"labels"`
+	Associations          []string          `json:"associations"`
+	Valence               float64           `json:"valence"`
+	ValenceClassification string            `json:"valenceClassification"`
+	Metadata              map[string]string `json:"metadata"`
+}
+
+// Symptom defines a single symptom entry.
+type Symptom struct {
+	Start       *Time  `json:"start"`
+	End         *Time  `json:"end"`
+	Name        string `json:"name"`
+	Severity    string `json:"severity"`
+	UserEntered bool   `json:"userEntered"`
+	Source      string `json:"source"`
+	CycleStart  bool   `json:"cycleStart"`
 }
 
 // Workout defines a single recorded Workout.


### PR DESCRIPTION
This PR adds support for ingesting two new data types from Health Auto Export: State of Mind and 
Symptoms

Changes include:

- New Data Types:
  - Defined `StateOfMind` and `Symptom` structs in `pkg/healthautoexport/types.go`
  - Updated `PayloadData` to include the new data types
- InfluxDB Backend:
  - Implemented logic to process and write `State of Mind` and `Symptom` data to InfluxDB, correctly mapping fields and tags for effective querying
- Time Parsing:
  - Added time.RFC3339 to the list of supported time formats to handle timestamps from the new data sources.